### PR TITLE
Add 2 dark options to map styles

### DIFF
--- a/static/data/mapstyle.json
+++ b/static/data/mapstyle.json
@@ -3,5 +3,7 @@
   "styleblackandwhite": "Black and White",
   "styletopo": "ToPo Map",
   "stylesatellite": "Satellite",
-  "stylewikipedia": "Wikipedia"
+  "stylewikipedia": "Wikipedia",
+  "stylecartodbdark": "Dark",
+  "stylecartodbdarknolabels": "Dark (No Labels)"
 }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -356,6 +356,8 @@ var styleblackandwhite = L.tileLayer('https://korona.geog.uni-heidelberg.de/tile
 var styletopo = L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'})
 var stylesatellite = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community'})
 var stylewikipedia = L.tileLayer('https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}{r}.png', {attribution: '<a href="https://wikimediafoundation.org/wiki/Maps_Terms_of_Use">Wikimedia</a>'})
+var stylecartodbdark = L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'})
+var stylecartodbdarknolabels = L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}{r}.png', {attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'})
 
 function setTitleLayer(layername) {
     if (map.hasLayer(window[_oldlayer])) { map.removeLayer(window[_oldlayer]) }


### PR DESCRIPTION
## Description
Add 2 dark options to map styles using CARTO's DarkMatter themes as the backend which is the same used by MadMin.

https://leaflet-extras.github.io/leaflet-providers/preview/#filter=CartoDB.DarkMatter

## Motivation and Context
I just missed the dark map themes so others might too!

## How Has This Been Tested?
Added to my RM instance earlier today, haven't encountered any issues so far.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.