### PR TITLE
fix raid eggs hatch time not displayed due to misplaced span

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -928,7 +928,7 @@ function gymLabel(gym, includeMembers = true) {
                   <span style='color:rgb(${raidColor[Math.floor((raid.level - 1) / 2)]})'>
                   ${levelStr}
                   </span>
-                  Raid in <span class='raid countdown label-countdown' disappears-at='${raid.start}'> (${moment(raid.start).format('HH:mm')})</span>
+                  Raid in <span class='raid countdown label-countdown' disappears-at='${raid.start}'></span> (${moment(raid.start).format('HH:mm')})
                 </div>`
         }
     } else {


### PR DESCRIPTION
## Description
Misplaced span causing the raid eggs to only display the remaining time before hatching and not the exact hatch time in parenthesis like raids bosses. Raid bosses are correct, not change needed there.

Credits to ShocWave for this find!

## Motivation and Context
Fix a display bug to improve quality of life!

## How Has This Been Tested?
Own instance and others reporting it fixes the issue.

## Screenshots (if appropriate):
![pr-span](https://user-images.githubusercontent.com/46268060/52130522-6786eb80-2608-11e9-9ad1-38f2b2b219b5.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
