### PR TITLE
Fix filter search showing wrong types

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -3035,7 +3035,7 @@ $(function () {
             $.each(value['types'], function (key, pokemonType) {
                 typestring[key] = i8ln(pokemonType['type'])
                 if (key < 1) {
-                    typestring[key+1] = i8ln(pokemonType['type']
+                    typestring[key+1] = i8ln(pokemonType['type'])
                 }
             })
             value['gen'] = getPokemonGen(key)

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -3034,6 +3034,9 @@ $(function () {
             value['name'] = i8ln(value['name'])
             $.each(value['types'], function (key, pokemonType) {
                 typestring[key] = i8ln(pokemonType['type'])
+                if (key < 1) {
+                    typestring[key+1] = i8ln(pokemonType['type']
+                }
             })
             value['gen'] = getPokemonGen(key)
             $('.list').append('<div class=pokemon-icon-sprite data-gen=gen' + value['gen'] + ' data-pkm=' + i8ln(value['name']) + ' data-value=' + key + ' data-type1=' + typestring[0] + ' data-type2=' + typestring[1] + '><div id=pkid_list>#' + key + '</div>' + pokemonIcon + '<div id=pkname_list>' + i8ln(value['name']) + '</div></div>')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Pokémon list for the filter is generated wrong because the types are not being reset inside the for-loop. This is a very easy and dirty fix giving single type Pokémon two types of the same kind.

But the filter is now working again.

What happened in detail?
Example: **Grimer**
![wrong_type](https://user-images.githubusercontent.com/21021281/52540052-895d3c80-2d85-11e9-8ec9-f5f60e50be69.png)

Grimer is single type: _poison_
Because of Dewgong's second type: _ice_ Grimer will get it too.
Same happens for all other single type Pokémon.

The fix will give Grimer type[1] : _posion_, type[2] : _poison_.

With this method we don't need extra code for checking type: _null_ or _undefined_ in the whole filter part. (Dirty fix)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)