### PR TITLE
Add determined spawnpoints from MAD database to map

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1349,14 +1349,13 @@ class SpawnPoint(LatLongModel):
                 key = sp['id']
                 sp['links'] = 'hh??'
                 sp['kind'] = 'hhss'
-                sp['earliest_unseen'] = int(int(sp['earliest_unseen'][0:2])*60
-                    + int(sp['earliest_unseen'][3:5]))
+                sp['earliest_unseen'] = int(int(sp['earliest_unseen'][:2])*60
+                    + int(sp['earliest_unseen'][-2:]))
                 sp['latest_seen'] = sp['earliest_unseen']
                 appear_time, disappear_time = SpawnPoint.start_end(sp)
                 spawnpoints[key] = sp
                 spawnpoints[key]['disappear_time'] = disappear_time
                 spawnpoints[key]['appear_time'] = appear_time
-
 
         # Helping out the GC.
         for sp in spawnpoints.values():

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1349,8 +1349,8 @@ class SpawnPoint(LatLongModel):
                 key = sp['id']
                 sp['links'] = 'hh??'
                 sp['kind'] = 'hhss'
-                sp['earliest_unseen'] = int(int(sp['earliest_unseen'][:2])*60
-                    + int(sp['earliest_unseen'][-2:]))
+                sp['earliest_unseen'] = (int(sp['earliest_unseen'].split(':')[0]) * 60
+                    + int(sp['earliest_unseen'].split(':')[1]))
                 sp['latest_seen'] = sp['earliest_unseen']
                 appear_time, disappear_time = SpawnPoint.start_end(sp)
                 spawnpoints[key] = sp

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1308,53 +1308,58 @@ class SpawnPoint(LatLongModel):
                         oSwLat=None, oSwLng=None, oNeLat=None, oNeLng=None):
         spawnpoints = {}
         with SpawnPoint.database().execution_context():
-            query = (SpawnPoint.select(
-                SpawnPoint.latitude, SpawnPoint.longitude, SpawnPoint.id,
-                SpawnPoint.links, SpawnPoint.kind, SpawnPoint.latest_seen,
-                SpawnPoint.earliest_unseen, ScannedLocation.done)
-                     .join(ScanSpawnPoint).join(ScannedLocation).dicts())
+            query = (trs_spawn.select(
+                trs_spawn.latitude, trs_spawn.longitude,
+                trs_spawn.spawnpoint.alias('id'),
+                trs_spawn.calc_endminsec.alias('latest_seen'),
+                trs_spawn.calc_endminsec.alias('earliest_unseen')).dicts())
 
             if timestamp > 0:
                 query = (
-                    query.where(((SpawnPoint.last_scanned >
+                    query.where(((trs_spawn.last_scanned >
                                   datetime.utcfromtimestamp(timestamp / 1000)))
-                                & ((SpawnPoint.latitude >= swLat) &
-                                   (SpawnPoint.longitude >= swLng) &
-                                   (SpawnPoint.latitude <= neLat) &
-                                   (SpawnPoint.longitude <= neLng))).dicts())
+                                & ((trs_spawn.latitude >= swLat) &
+                                   (trs_spawn.longitude >= swLng) &
+                                   (trs_spawn.latitude <= neLat) &
+                                   (trs_spawn.longitude <= neLng))).dicts())
             elif oSwLat and oSwLng and oNeLat and oNeLng:
                 # Send spawnpoints in view but exclude those within old
                 # boundaries. Only send newly uncovered spawnpoints.
                 query = (query
-                         .where((((SpawnPoint.latitude >= swLat) &
-                                  (SpawnPoint.longitude >= swLng) &
-                                  (SpawnPoint.latitude <= neLat) &
-                                  (SpawnPoint.longitude <= neLng))) &
-                                ~((SpawnPoint.latitude >= oSwLat) &
-                                  (SpawnPoint.longitude >= oSwLng) &
-                                  (SpawnPoint.latitude <= oNeLat) &
-                                  (SpawnPoint.longitude <= oNeLng)))
+                         .where((((trs_spawn.latitude >= swLat) &
+                                  (trs_spawn.longitude >= swLng) &
+                                  (trs_spawn.latitude <= neLat) &
+                                  (trs_spawn.longitude <= neLng))) &
+                                ~((trs_spawn.latitude >= oSwLat) &
+                                  (trs_spawn.longitude >= oSwLng) &
+                                  (trs_spawn.latitude <= oNeLat) &
+                                  (trs_spawn.longitude <= oNeLng)))
                          .dicts())
             elif swLat and swLng and neLat and neLng:
                 query = (query
-                         .where((SpawnPoint.latitude <= neLat) &
-                                (SpawnPoint.latitude >= swLat) &
-                                (SpawnPoint.longitude >= swLng) &
-                                (SpawnPoint.longitude <= neLng)))
+                         .where((trs_spawn.latitude <= neLat) &
+                                (trs_spawn.latitude >= swLat) &
+                                (trs_spawn.longitude >= swLng) &
+                                (trs_spawn.longitude <= neLng)))
+
+            query = (query.where(trs_spawn.calc_endminsec.is_null(False)))
 
             queryDict = query.dicts()
             for sp in queryDict:
                 key = sp['id']
+                sp['links'] = 'hh??'
+                sp['kind'] = 'hhss'
+                sp['earliest_unseen'] = int(int(sp['earliest_unseen'][0:2])*60
+                    + int(sp['earliest_unseen'][3:5]))
+                sp['latest_seen'] = sp['earliest_unseen']
                 appear_time, disappear_time = SpawnPoint.start_end(sp)
                 spawnpoints[key] = sp
                 spawnpoints[key]['disappear_time'] = disappear_time
                 spawnpoints[key]['appear_time'] = appear_time
-                if not SpawnPoint.tth_found(sp) or not sp['done']:
-                    spawnpoints[key]['uncertain'] = True
+
 
         # Helping out the GC.
         for sp in spawnpoints.values():
-            del sp['done']
             del sp['kind']
             del sp['links']
             del sp['latest_seen']
@@ -1760,6 +1765,24 @@ class SpawnpointDetectionData(BaseModel):
         sp['earliest_unseen'] = now_secs
 
         return True
+
+
+class trs_spawn(BaseModel):
+     spawnpoint = Utf8mb4CharField(primary_key=True, max_length=16, index=True)
+     latitude = DoubleField()
+     longitude = DoubleField()
+     spawndef = IntegerField()
+     earliest_unseen = IntegerField()
+     last_scanned = DateTimeField(null=True)
+     first_detection = DateTimeField(default=datetime.utcnow)
+     last_non_scanned = DateTimeField(null=True)
+     calc_endminsec = Utf8mb4CharField(null=True)
+
+     @staticmethod
+     def get_trsspawn():
+         query = (trs_spawn
+                     .select())
+         return list(query)
 
 
 class Versions(BaseModel):


### PR DESCRIPTION
## Description
Adds back spawnpoints but only determined ones.
In a very simple way...

Warning:
This first push is setting all spawnpoint-types to 30 minutes spawns.
Did this because I don't know if MAD is detecting 60 minutes spawns correctly.
(In madmin it is incorrect!)

Help for this is welcome.

I didn't want to destroy the old RM code because who knows the future. So I left unused code in the class.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally on my server.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
