### PR TITLE
Add Quest Filters

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -431,6 +431,11 @@ class Pogom(Flask):
             luredonly = True
         elif request.args.get('luredonly') == '2':
             luredonly = False
+        elif request.args.get('luredonly') == '3':
+            luredonly = False
+        elif request.args.get('luredonly') == '4':
+            luredonly = False
+
 
         # Current switch settings saved for next request.
         if request.args.get('gyms', 'true') == 'true':

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2011,6 +2011,16 @@ function processPokestop(i, item) {
     if (Store.get('showLuredPokestopsOnly') == 1 && !item['lure_expiration']) {
         return true
 	}
+    if (Store.get('showLuredPokestopsOnly') == 3){
+	return false
+	}
+    if (Store.get('showLuredPokestopsOnly') == 4){
+        return false
+        }
+    if (Store.get('showLuredPokestopsOnly') == 5){
+        return false
+        }
+
     //if (Store.get('showLuredPokestopsOnly') == 2 && !item['quest_raw']) {
     //    return true
 		//}
@@ -2079,6 +2089,46 @@ function updatePokestops() {
             if (!value['quest_raw']['is_quest']) {
                 removeStops.push(key)
             }
+        })
+        $.each(removeStops, function (key, value) {
+            if (mapData.pokestops[value] && mapData.pokestops[value].marker) {
+                if (mapData.pokestops[value].marker.rangeCircle) {
+                    markers.removeLayer(mapData.pokestops[value].marker.rangeCircle)
+                }
+                markers.removeLayer(mapData.pokestops[value].marker)
+                delete mapData.pokestops[key]
+            }
+        })
+    }
+    if (Store.get('showLuredPokestopsOnly') == 3) {
+        $.each(mapData.pokestops, function (key, value) {
+	    if (!value['quest_raw']['item_type']){
+		removeStops.push(key)
+	    }
+            else if (value['quest_raw']['item_type'] !== "Rare Candy") {
+                removeStops.push(key)
+            }
+	
+        })
+        $.each(removeStops, function (key, value) {
+            if (mapData.pokestops[value] && mapData.pokestops[value].marker) {
+                if (mapData.pokestops[value].marker.rangeCircle) {
+                    markers.removeLayer(mapData.pokestops[value].marker.rangeCircle)
+                }
+                markers.removeLayer(mapData.pokestops[value].marker)
+                delete mapData.pokestops[key]
+            }
+        })
+    }
+    if (Store.get('showLuredPokestopsOnly') == 4) {
+        $.each(mapData.pokestops, function (key, value) {
+            if (!value['quest_raw']['item_type']){
+                removeStops.push(key)
+            }
+            else if (value['quest_raw']['item_type'] !== "Silver Pinap") {
+                removeStops.push(key)
+            }
+
         })
         $.each(removeStops, function (key, value) {
             if (mapData.pokestops[value] && mapData.pokestops[value].marker) {

--- a/templates/map.html
+++ b/templates/map.html
@@ -206,7 +206,9 @@
               <select name="lured-pokestops-only-switch" id="lured-pokestops-only-switch">
                 <option value="0">All</option>
                 <option value="1">Only Lured</option>
-				<option value="2">Only Quest</option>
+				<option value="2">Only Quest (All)</option>
+                                <option value="3">Only Quest (Rare Candy)</option>
+                                <option value="4">Only Quest (Silver Pinap)</option>
               </select>
             </div>
               {% endif %}


### PR DESCRIPTION
Adding filters for Pinap and Rare Candy.  Doesn't fix refresh bug from MAD_Quests base in pokestop section (need to manually unfilter / filter if you select a granular filter).

