### PR TITLE
Fixed potential denial-of-service issue

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -112,6 +112,10 @@ class Pogom(Flask):
         raidlevel = request.args.get('raidlevel')
         pkm = request.args.get('pkm')
         is_in_battle = 'in_battle' in request.args
+
+        if (level > 6 or raidlevel > 5):
+            return abort(416)
+
         return send_file(get_gym_icon(
             team, level, raidlevel, pkm, is_in_battle), mimetype='image/png')
 
@@ -127,6 +131,7 @@ class Pogom(Flask):
         costume = int(
             request.args.get('costume')) if 'costume' in request.args else None
         shiny = 'shiny' in request.args
+
         if raw:
             filename = get_pokemon_raw_icon(
                 pkm, gender=gender, form=form,

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -113,7 +113,7 @@ class Pogom(Flask):
         pkm = request.args.get('pkm')
         is_in_battle = 'in_battle' in request.args
 
-        if (level < 0 or level > 6 or raidlevel < 0 or raidlevel > 5):
+        if (int(level) < 0 or int(level) > 6 or int(raidlevel) < 0 or int(raidlevel) > 5):
             return abort(416)
 
         return send_file(get_gym_icon(

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -113,7 +113,7 @@ class Pogom(Flask):
         pkm = request.args.get('pkm')
         is_in_battle = 'in_battle' in request.args
 
-        if (level > 6 or raidlevel > 5):
+        if (level < 0 or level > 6 or raidlevel < 0 or raidlevel > 5):
             return abort(416)
 
         return send_file(get_gym_icon(


### PR DESCRIPTION
Right now, anyone could slowly fill up a target machine running OSM-Rocketmap by calling /gym_img very often. This PR fixes this issue.
## Description
The gym_img endpoint does not validate input. Due to this, anyone could slowly fill up a target machine's disk space by GET-ing `/gym_img?team=Valor&level=x&raidlevel=y&pkm=308` thousands of times and increasing `x` and `y` after every request.
This PR validates the raid and arena level before generating a new image.

## Motivation and Context
This change is required because it makes this fork more secure from baddies.

## How Has This Been Tested?
I ran this and did not find any issues.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. (not required)
- [ ] I have updated the documentation accordingly. (not required)
