### PR TITLE
Fix: Moves - Cannot read property 'type' of undefined`

### DIFF
--- a/static/data/moves.json
+++ b/static/data/moves.json
@@ -1830,5 +1830,229 @@
         "duration": 1300,
         "energy": 20,
         "dps": 3.8
+    },
+    "292": {
+        "name": "Weather Ball",
+        "type": "Fire",
+        "damage": 60,
+        "duration": 1600,
+        "energy": 33,
+        "dps": 37.5
+    },
+    "293": {
+        "name": "Weather Ball",
+        "type": "Ice",
+        "damage": 60,
+        "duration": 1600,
+        "energy": 33,
+        "dps": 37.5
+    },
+    "294": {
+        "name": "Weather Ball",
+        "type": "Rock",
+        "damage": 60,
+        "duration": 1600,
+        "energy": 33,
+        "dps": 37.5
+    },
+    "295": {
+        "name": "Weather Ball",
+        "type": "Water",
+        "damage": 60,
+        "duration": 1600,
+        "energy": 33,
+        "dps": 37.5
+    },
+    "296": {
+        "name": "Frenzy Plant",
+        "type": "Grass",
+        "damage": 100,
+        "duration": 2600,
+        "energy": 100,
+        "dps": 38.4
+    },
+    "297": {
+        "name": "Smack Down",
+        "type": "Rock",
+        "damage": 16,
+        "duration": 1200,
+        "energy": 8,
+        "dps": 13.3
+    },
+    "298": {
+        "name": "Blast Burn",
+        "type": "Fire",
+        "damage": 110,
+        "duration": 3300,
+        "energy": 100,
+        "dps": 33.3
+    },
+    "299": {
+        "name": "Hydro Cannon",
+        "type": "Water",
+        "damage": 90,
+        "duration": 1900,
+        "energy": 100,
+        "dps": 47.4
+    },
+    "300": {
+        "name": "Last Resort",
+        "type": "Normal",
+        "damage": 90,
+        "duration": 2700,
+        "energy": 100,
+        "dps": 31
+    },
+    "301": {
+        "name": "Meteor Mash",
+        "type": "Steel",
+        "damage": 100,
+        "duration": 2600,
+        "energy": 100,
+        "dps": 38.4
+    },
+    "302": {
+        "name": "Skull Bash",
+        "type": "Normal",
+        "damage": 0,
+        "duration": 0,
+        "energy": 0,
+        "dps": 0
+    },
+    "303": {
+        "name": "Acid Spray",
+        "type": "Poison",
+        "damage": 20,
+        "duration": 3000,
+        "energy": 20,
+        "dps": 38.5
+    },
+    "304": {
+        "name": "Earth Power",
+        "type": "Ground",
+        "damage": 0,
+        "duration": 0,
+        "energy": 0,
+        "dps": 0
+    },
+    "305": {
+        "name": "Crabhammer",
+        "type": "Water",
+        "damage": 0,
+        "duration": 0,
+        "energy": 0,
+        "dps": 0
+    },
+    "306": {
+        "name": "Lunge",
+        "type": "Bug",
+        "damage": 0,
+        "duration": 0,
+        "energy": 0,
+        "dps": 0
+    },
+    "307": {
+        "name": "Crush Claw",
+        "type": "Normal",
+        "damage": 0,
+        "duration": 0,
+        "energy": 0,
+        "dps": 0
+    },
+    "308": {
+        "name": "Octazooka",
+        "type": "Water",
+        "damage": 0,
+        "duration": 0,
+        "energy": 0,
+        "dps": 0
+    },
+    "309": {
+        "name": "Mirror Shot",
+        "type": "Steel",
+        "damage": 0,
+        "duration": 0,
+        "energy": 0,
+        "dps": 0
+    },
+    "310": {
+        "name": "Superpower",
+        "type": "Fighting",
+        "damage": 0,
+        "duration": 0,
+        "energy": 0,
+        "dps": 0
+    },
+    "311": {
+        "name": "Fell Stinger",
+        "type": "Bug",
+        "damage": 0,
+        "duration": 0,
+        "energy": 0,
+        "dps": 0
+    },
+    "312": {
+        "name": "Leaf Tornado",
+        "type": "Grass",
+        "damage": 45,
+        "duration": 3100,
+        "energy": 45,
+        "dps": 38.5
+    },
+    "313": {
+        "name": "Leech Life",
+        "type": "Bug",
+        "damage": 0,
+        "duration": 0,
+        "energy": 0,
+        "dps": 0
+    },
+    "314": {
+        "name": "Drain Punch",
+        "type": "Fighting",
+        "damage": 0,
+        "duration": 0,
+        "energy": 0,
+        "dps": 0
+    },
+    "315": {
+        "name": "Shadow Bone",
+        "type": "Ghost",
+        "damage": 0,
+        "duration": 0,
+        "energy": 0,
+        "dps": 0
+    },
+    "316": {
+        "name": "Muddy Water",
+        "type": "Water",
+        "damage": 0,
+        "duration": 0,
+        "energy": 0,
+        "dps": 0
+    },
+    "317": {
+        "name": "Blaze Kick",
+        "type": "Fire",
+        "damage": 0,
+        "duration": 0,
+        "energy": 0,
+        "dps": 0
+    },
+    "318": {
+        "name": "Razor Shell",
+        "type": "Water",
+        "damage": 0,
+        "duration": 0,
+        "energy": 0,
+        "dps": 0
+    },
+    "319": {
+        "name": "Power-Up Punch",
+        "type": "Fighting",
+        "damage": 50,
+        "duration": 2000,
+        "energy": 33,
+        "dps": 25.0
     }
 }


### PR DESCRIPTION
## Description
This adds the new moves recently added to the game to fix the display issue (see below).

I also added the unused and future moves so RM remains functional between their introduction and an update to add their official stats.

Translations are already present in the french locale so I am assuming they are present in others as well.

## Motivation and Context
Fixes the following error seen in browser console due to missing moves causing some gyms not to appear or unclickable when a raid boss has one of the new moves.
```
map.min.js:5 Uncaught TypeError: Cannot read property 'type' of undefined
    at gymLabel (map.min.js:5)
    at updateGymMarker (map.min.js:5)
    at setupGymMarker (map.min.js:5)
    at Object.processGym (map.min.js:5)
    at Function.each (jquery.min.js:2)
    at Object.<anonymous> (map.min.js:5)
```
## How Has This Been Tested?
Locally!

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.