### PR TITLE
Update gym badges

### DIFF
--- a/pogom/dyn_img.py
+++ b/pogom/dyn_img.py
@@ -367,7 +367,7 @@ def draw_badge(pos, fill_col, text_col, text):
         '-gravity center -fill {} -stroke none '.format(
             text_col),
         '-draw "text {},{} \'{}\'"'.format(
-            x - 48, y - 49, text)
+            x - 47, y - 49, text)
     ]
     return lines
 

--- a/pogom/dyn_img.py
+++ b/pogom/dyn_img.py
@@ -77,6 +77,12 @@ badge_lower_right = (
     gym_icon_size - (gym_badge_padding + gym_badge_radius),
     gym_icon_size - (gym_badge_padding + gym_badge_radius))
 
+team_colors = {
+    "Mystic": "rgb(30,160,225)",
+    "Valor": "rgb(255,26,26)",
+    "Instinct": "rgb(255,190,8)"
+}
+
 font = os.path.join(path_static, 'Arial Black.ttf')
 font_pointsize = 25
 
@@ -165,7 +171,7 @@ def get_gym_icon(team, level, raidlevel, pkm, is_in_battle, form):
         im_lines.extend(draw_raid_pokemon(pkm, form))
         im_lines.extend(draw_raid_level(raidlevel))
         if level > 0:
-            im_lines.extend(draw_gym_level(level))
+            im_lines.extend(draw_gym_level(level, team))
     elif raidlevel:
         # Gym with upcoming raid (egg)
         raidlevel = int(raidlevel)
@@ -175,13 +181,13 @@ def get_gym_icon(team, level, raidlevel, pkm, is_in_battle, form):
         im_lines.extend(draw_raid_egg(raidlevel))
         im_lines.extend(draw_raid_level(raidlevel))
         if level > 0:
-            im_lines.extend(draw_gym_level(level))
+            im_lines.extend(draw_gym_level(level, team))
     elif level > 0:
         # Occupied gym
         out_filename = os.path.join(
             path_generated_gym,
             '{}_L{}.png'.format(team, level))
-        im_lines.extend(draw_gym_level(level))
+        im_lines.extend(draw_gym_level(level, team))
     else:
         # Neutral gym
         return os.path.join(path_gym, '{}.png'.format(team))
@@ -212,8 +218,8 @@ def draw_raid_egg(raidlevel):
     return draw_gym_subject(egg_path, 36, gravity='center')
 
 
-def draw_gym_level(level):
-    return draw_badge(badge_lower_right, "black", "white", level)
+def draw_gym_level(level, team):
+    return draw_badge(badge_lower_right, team_colors[team], "white", level)
 
 
 def draw_raid_level(raidlevel):

--- a/pogom/dyn_img.py
+++ b/pogom/dyn_img.py
@@ -82,6 +82,7 @@ team_colors = {
     "Valor": "rgb(255,26,26)",
     "Instinct": "rgb(255,190,8)"
 }
+raid_colors = ["rgb(252,112,176)", "rgb(255,158,22)", "rgb(184,165,221)"]
 
 font = os.path.join(path_static, 'Arial Black.ttf')
 font_pointsize = 25
@@ -169,7 +170,7 @@ def get_gym_icon(team, level, raidlevel, pkm, is_in_battle, form):
             "{}_L{}_R{}_P{}{}.png".format(team, level, raidlevel, pkm, form_extension)
         )
         im_lines.extend(draw_raid_pokemon(pkm, form))
-        im_lines.extend(draw_raid_level(raidlevel))
+        im_lines.extend(draw_raid_level(int(raidlevel)))
         if level > 0:
             im_lines.extend(draw_gym_level(level, team))
     elif raidlevel:
@@ -223,7 +224,9 @@ def draw_gym_level(level, team):
 
 
 def draw_raid_level(raidlevel):
-    return draw_badge(badge_upper_right, "white", "black", raidlevel)
+    return draw_badge(
+        badge_upper_right, raid_colors[int((raidlevel -1) / 2)], "white",
+        raidlevel)
 
 
 def draw_battle_indicator():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR updates the look of the gym badges. The level is now properly centered inside the badge (it was one pixel off). The gym level badge now has the same color as the gym and the raid badge has a color based on the raid level: pink for 1-2, yellow for 3-4, and purple for level 5.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local instance.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22012675/59271061-5784b580-8c53-11e9-9347-5769816da68a.png)
Ignore the black around the raid pokemon/eggs. ImageMagick doesn't quite work the same on windows apparently.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
