### PR TITLE
Fix css for gym info.

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -804,7 +804,7 @@ function gymLabel(gym) {
             </div>`*/
 
         gymLeaderDisplay = `
-            <div class='gym gym-leader'>
+            <div>
               Gym leader: <span class='info'>${idToPokemon[gym.guard_pokemon_id].name}</span>
               <a class='info' href='https://pokemongo.gamepress.gg/pokemon/${gym.guard_pokemon_id}' target='_blank' title='View on GamePress'>#${gym.guard_pokemon_id}</a>
             </div>`
@@ -920,11 +920,13 @@ function gymLabel(gym) {
             </div>
             <div class='gym container content-right'>
               <div>
-                ${strenghtDisplay}
-                <div>
-                  Free slots: <span class='info'>${gym.slots_available}</span>
+                <div class='gym gym-info'>
+                  ${strenghtDisplay}
+                  <div>
+                    Free slots: <span class='info'>${gym.slots_available}</span>
+                  </div>
+                  ${gymLeaderDisplay}
                 </div>
-                ${gymLeaderDisplay}
                 <div>
                   Last scanned: <span class='info'>${getDateStr(gym.last_scanned)}</span>
                 </div>

--- a/static/sass/layout/_gym.scss
+++ b/static/sass/layout/_gym.scss
@@ -63,7 +63,7 @@
     color: rgba(255,159,25,1);
   }
 
-  &.gym-leader {
+  &.gym-info {
     margin-bottom: 13px;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This applies the margin-bottom of 13px to a div wrapping all gym info. Before it was applied only to the div containing the gym leader pokemon.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The div containing the gym leader pokemon is not shown for uncontested gyms.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local instance.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
