### PR TITLE
Fix Ex Eligible Raids Only toggle

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -758,6 +758,10 @@ function isGymSatisfiesRaidMinMaxFilter(raid) {
     return raid && raid['level'] <= Store.get('showRaidMaxLevel') && raid['level'] >= Store.get('showRaidMinLevel')
 }
 
+function isGymSatisfiesRaidExEligibleFilter(raid) {
+    return raid && (!Store.get('showParkRaidsOnly') || raid.is_ex_raid_eligible)
+}
+
 function gymLabel(gym) {
     const raid = gym.raid
     const teamName = gymTypes[gym.team_id]
@@ -1363,13 +1367,13 @@ function updateGymMarker(gym, marker) {
     let markerImage = ''
     var zIndexOffset
 
-    if (gym.raid && isOngoingRaid(gym.raid) && Store.get('showRaids') && raidLevel >= Store.get('showRaidMinLevel') && raidLevel <= Store.get('showRaidMaxLevel')) {
+    if (gym.raid && isOngoingRaid(gym.raid) && Store.get('showRaids') && raidLevel >= Store.get('showRaidMinLevel') && raidLevel <= Store.get('showRaidMaxLevel') && isGymSatisfiesRaidExEligibleFilter(gym.raid)) {
         markerImage = 'gym_img?team=' + gymTypes[gym.team_id] + '&level=' + getGymLevel(gym) + '&raidlevel=' + gym['raid']['level'] + '&pkm=' + gym['raid']['pokemon_id']
         if (gym.raid.form) {
             markerImage += '&form=' + gym.raid.form
         }
         zIndexOffset = 100
-    } else if (gym.raid && gym.raid.end > Date.now() && Store.get('showRaids') && !Store.get('showActiveRaidsOnly') && raidLevel >= Store.get('showRaidMinLevel') && raidLevel <= Store.get('showRaidMaxLevel')) {
+    } else if (gym.raid && gym.raid.end > Date.now() && Store.get('showRaids') && !Store.get('showActiveRaidsOnly') && raidLevel >= Store.get('showRaidMinLevel') && raidLevel <= Store.get('showRaidMaxLevel') && isGymSatisfiesRaidExEligibleFilter(gym.raid)) {
         markerImage = 'gym_img?team=' + gymTypes[gym.team_id] + '&level=' + getGymLevel(gym) + '&raidlevel=' + gym['raid']['level']
         zIndexOffset = 20
     } else {
@@ -3212,7 +3216,7 @@ $(function () {
         var pokemonIcon
         var typestring = []
         var pokeList = []
-        
+
         function populateLists(id, pokemonData) {
           if (generateImages) {
               pokemonIcon = `<img class='pokemon-select-icon' src='${getPokemonRawIconUrl({'pokemon_id': id})}'>`

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -754,12 +754,12 @@ function isValidRaid(raid) {
     // && Date.now() > raid.spawn
 }
 
-function isGymSatisfiesRaidMinMaxFilter(raid) {
+function isRaidSatisfiesRaidMinMaxFilter(raid) {
     return raid && raid['level'] <= Store.get('showRaidMaxLevel') && raid['level'] >= Store.get('showRaidMinLevel')
 }
 
-function isGymSatisfiesRaidExEligibleFilter(raid) {
-    return raid && (!Store.get('showParkRaidsOnly') || raid.is_ex_raid_eligible)
+function isGymSatisfiesRaidExEligibleFilter(gym) {
+    return gym.raid && (!Store.get('showParkRaidsOnly') || gym.is_ex_raid_eligible)
 }
 
 function gymLabel(gym) {
@@ -819,7 +819,7 @@ function gymLabel(gym) {
             </div>`
     }
 
-    if ((isRaidUpcoming || isRaidOngoing) && isRaidFilterOn && isGymSatisfiesRaidMinMaxFilter(raid)) {
+    if ((isRaidUpcoming || isRaidOngoing) && isRaidFilterOn && isRaidSatisfiesRaidMinMaxFilter(raid)) {
         const raidColor = ['252,112,176', '255,158,22', '184,165,221']
         const levelStr = '★'.repeat(raid.level)
 
@@ -1367,13 +1367,13 @@ function updateGymMarker(gym, marker) {
     let markerImage = ''
     var zIndexOffset
 
-    if (gym.raid && isOngoingRaid(gym.raid) && Store.get('showRaids') && raidLevel >= Store.get('showRaidMinLevel') && raidLevel <= Store.get('showRaidMaxLevel') && isGymSatisfiesRaidExEligibleFilter(gym.raid)) {
+    if (gym.raid && isOngoingRaid(gym.raid) && Store.get('showRaids') && raidLevel >= Store.get('showRaidMinLevel') && raidLevel <= Store.get('showRaidMaxLevel') && isGymSatisfiesRaidExEligibleFilter(gym)) {
         markerImage = 'gym_img?team=' + gymTypes[gym.team_id] + '&level=' + getGymLevel(gym) + '&raidlevel=' + gym['raid']['level'] + '&pkm=' + gym['raid']['pokemon_id']
         if (gym.raid.form) {
             markerImage += '&form=' + gym.raid.form
         }
         zIndexOffset = 100
-    } else if (gym.raid && gym.raid.end > Date.now() && Store.get('showRaids') && !Store.get('showActiveRaidsOnly') && raidLevel >= Store.get('showRaidMinLevel') && raidLevel <= Store.get('showRaidMaxLevel') && isGymSatisfiesRaidExEligibleFilter(gym.raid)) {
+    } else if (gym.raid && gym.raid.end > Date.now() && Store.get('showRaids') && !Store.get('showActiveRaidsOnly') && raidLevel >= Store.get('showRaidMinLevel') && raidLevel <= Store.get('showRaidMaxLevel') && isGymSatisfiesRaidExEligibleFilter(gym)) {
         markerImage = 'gym_img?team=' + gymTypes[gym.team_id] + '&level=' + getGymLevel(gym) + '&raidlevel=' + gym['raid']['level']
         zIndexOffset = 20
     } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes the Ex Eligible Raids Only toggle when the Gyms toggle is enabled.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before when all gyms are show the Ex Eligible Raids Only toggle didn't have any effect. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local instance.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
