### PR TITLE
 Only check lured pokestops for expired lure + some fixes

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2127,12 +2127,6 @@ function processPokestop(i, pokestop) {
         }
 
         // New pokestop, add marker to map and item to dict.
-        if (pokestop.marker && pokestop.marker.rangeCircle) {
-            markers.removeLayer(pokestop.marker.rangeCircle)
-        }
-        if (pokestop.marker) {
-            markers.removeLayer(pokestop.marker)
-        }
         pokestop.marker = setupPokestopMarker(pokestop)
         mapData.pokestops[pokestop['pokestop_id']] = pokestop
     } else {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -63,6 +63,8 @@ var buffer = []
 var reincludedPokemon = []
 var reids = []
 
+var luredPokestops = []
+
 // var map
 var markerCluster = window.markerCluster = {}
 var rawDataIsLoading = false
@@ -2102,11 +2104,11 @@ function updateLuredPokestops() {
     var currentTime = new Date().getTime()
     // Change lured pokestop marker to unlured when lure has expired.
     $.each(mapData.pokestops, function (key, pokestop) {
-        if (pokestop['lure_expiration'] && pokestop['lure_expiration'] < currentTime) {
-            pokestop['lure_expiration'] = null
-            pokestop['active_fort_modifier'] = null
+        if (pokestop.lure_expiration && pokestop.lure_expiration <= currentTime) {
+            mapData.pokestops[pokestop.pokestop_id].lure_expiration = null
+            mapData.pokestops[pokestop.pokestop_id].active_fort_modifier = null
             if (isPokestopSatisfiesFilters(pokestop)) {
-                updatePokestopMarker(pokestop, pokestop.marker)
+                updatePokestopMarker(pokestop, mapData.pokestops[pokestop.pokestop_id].marker)
             } else {
                 removePokestop(pokestop)
             }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -63,7 +63,7 @@ var buffer = []
 var reincludedPokemon = []
 var reids = []
 
-var luredPokestops = []
+var luredPokestops = {}
 
 // var map
 var markerCluster = window.markerCluster = {}
@@ -2081,6 +2081,9 @@ function removePokestop(pokestop) {
       }
       markers.removeLayer(mapData.pokestops[pokestop.pokestop_id].marker)
       delete mapData.pokestops[pokestop.pokestop_id]
+      if (luredPokestops[pokestop.pokestop_id]) {
+          delete luredPokestops[pokestop.pokestop_id]
+      }
   }
 }
 
@@ -2096,19 +2099,20 @@ function updatePokestops() {
     updateMap()
 }
 
+// For each lured pokestop change the marker to unlured if the lure has expired.
 function updateLuredPokestops() {
     if (!Store.get('showPokestops')) {
         return false
     }
 
     var currentTime = new Date().getTime()
-    // Change lured pokestop marker to unlured when lure has expired.
-    $.each(mapData.pokestops, function (key, pokestop) {
+    $.each(luredPokestops, function (key, pokestop) {
         if (pokestop.lure_expiration && pokestop.lure_expiration <= currentTime) {
-            mapData.pokestops[pokestop.pokestop_id].lure_expiration = null
-            mapData.pokestops[pokestop.pokestop_id].active_fort_modifier = null
             if (isPokestopSatisfiesFilters(pokestop)) {
-                updatePokestopMarker(pokestop, mapData.pokestops[pokestop.pokestop_id].marker)
+                mapData.pokestops[pokestop.pokestop_id].lure_expiration = null
+                mapData.pokestops[pokestop.pokestop_id].active_fort_modifier = null
+                updatePokestopMarker(mapData.pokestops[pokestop.pokestop_id], mapData.pokestops[pokestop.pokestop_id].marker)
+                delete luredPokestops[pokestop.pokestop_id]
             } else {
                 removePokestop(pokestop)
             }
@@ -2121,21 +2125,27 @@ function processPokestop(i, pokestop) {
         return false // in case the checkbox was unchecked in the meantime.
     }
 
-    if (!mapData.pokestops[pokestop['pokestop_id']]) {
+    if (!mapData.pokestops[pokestop.pokestop_id]) {
         if (!isPokestopSatisfiesFilters(pokestop)) {
             return true
         }
-
         // New pokestop, add marker to map and item to dict.
         pokestop.marker = setupPokestopMarker(pokestop)
-        mapData.pokestops[pokestop['pokestop_id']] = pokestop
+        mapData.pokestops[pokestop.pokestop_id] = pokestop
+        if (pokestop.lure_expiration) {
+            luredPokestops[pokestop.pokestop_id] = pokestop
+        }
     } else {
-        // Existing pokestop, update marker if necessary.
-        var pokestop2 = mapData.pokestops[pokestop['pokestop_id']]
-        if (!!pokestop['lure_expiration'] !== !!pokestop2['lure_expiration'] ||
-            !!pokestop['quest_raw']['quest_reward_type_raw'] !== !!pokestop2['quest_raw']['quest_reward_type_raw']) {
+        // Existing pokestop, update marker and dict item if necessary.
+        var pokestop2 = mapData.pokestops[pokestop.pokestop_id]
+        var newLure = pokestop.lure_expiration && !pokestop2.lure_expiration
+        if (newLure || !!pokestop.quest_raw.quest_reward_type_raw !== !!pokestop2.quest_raw.quest_reward_type_raw) {
             if (isPokestopSatisfiesFilters(pokestop)) {
-                updatePokestopMarker(pokestop, mapData.pokestops[pokestop['pokestop_id']].marker)
+                updatePokestopMarker(pokestop, mapData.pokestops[pokestop.pokestop_id].marker)
+                mapData.pokestops[pokestop.pokestop_id] = pokestop
+                if (newLure) {
+                    luredPokestops[pokestop.pokestop_id] = pokestop
+                }
             } else {
                 removePokestop(pokestop)
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
All pokestops were previously checked for expiring lures on every map update. This is ofcourse very inefficient. Now only lured pokestops are checked.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
