### PR TITLE
Improvements to pokemon filtering

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -3239,7 +3239,7 @@ $(function () {
     $.getJSON('static/dist/data/pokemon.min.json').done(function (data) {
         var pokemonIcon
         var typestring = []
-        var pokeList = []
+        var pokemonIds = []
 
         function populateLists(id, pokemonData) {
           if (generateImages) {
@@ -3269,6 +3269,7 @@ $(function () {
         var id
         for (id = 1; id <= numberOfPokemon; id++) {
             populateLists(id, data[id])
+            pokemonIds.push(id)
         }
         // Meltan and Melmetal
         populateLists(808, data[808])
@@ -3282,43 +3283,34 @@ $(function () {
 
         $('.list').on('click', '.pokemon-icon-sprite', function () {
             var img = $(this)
-            var select = $(this).parent().parent().find('input[id$=pokemon]')
-            var value = select.val().split(',')
-            $(this).find('.hidepreset').removeClass('active')
+            var inputElement = $(this).parent().parent().find('input[id$=pokemon]')
+            var value = inputElement.val().length > 0 ? inputElement.val().split(',') : []
             var id = img.data('value').toString()
-            $('.hidepreset').removeClass('active')
             if (img.hasClass('active')) {
-                select.val(value.filter(function (elem) {
+                inputElement.val(value.filter(function (elem) {
                     return elem !== id
                 }).join(',')).trigger('change')
                 img.removeClass('active')
             } else {
-                select.val((value.concat(id).join(','))).trigger('change')
+                inputElement.val((value.concat(id).join(','))).trigger('change')
                 img.addClass('active')
             }
         })
 
         $('.quest-item-list').on('click', '.quest-item-sprite', function () {
             var img = $(this)
-            var select = $(this).parent().parent().find('input[id$=items]')
-            var value = select.val().split(',')
+            var inputElement = $(this).parent().parent().find('input[id$=items]')
+            var value = inputElement.val().length > 0 ? inputElement.val().split(',') : []
             var id = img.data('value').toString()
             if (img.hasClass('active')) {
-                select.val(value.filter(function (elem) {
+                inputElement.val(value.filter(function (elem) {
                     return elem !== id
                 }).join(',')).trigger('change')
                 img.removeClass('active')
             } else {
-                select.val((value.concat(id).join(','))).trigger('change')
+                inputElement.val((value.concat(id).join(','))).trigger('change')
                 img.addClass('active')
             }
-        })
-
-        $('.quest-item-show-all').on('click', function (e) {
-            e.preventDefault()
-            var parent = $(this).parent().parent()
-            parent.find('.quest-item-list .quest-item-sprite').removeClass('active')
-            parent.find('input[id$=items]').val('').trigger('change')
         })
 
         $('.exclude_templates').on('click', '.hidepreset', function () {
@@ -3336,13 +3328,13 @@ $(function () {
             var foundpokemon = []
             var pokeselectlist = $(this).next('.list').find('.pokemon-icon-sprite')
             if (searchtext === '') {
-                parent.parent().find('.select-all, .select-reverse').hide()
-                parent.parent().find('.hide-all').show()
+                parent.parent().find('.pokemon-select-filtered, .pokemon-select-unfiltered, .pokemon-deselect-filtered, .pokemon-deselect-unfiltered').hide()
+                parent.parent().find('.pokemon-select-all, .pokemon-deselect-all').show()
                 pokeselectlist.show()
             } else {
                 pokeselectlist.hide()
-                parent.parent().find('.select-all, .select-reverse').show()
-                parent.parent().find('.hide-all').hide()
+                parent.parent().find('.pokemon-select-filtered, .pokemon-select-unfiltered, .pokemon-deselect-filtered, .pokemon-deselect-unfiltered').show()
+                parent.parent().find('.pokemon-select-all, .pokemon-deselect-all').hide()
                 foundpokemon = filterpokemon(pokeSearchList, searchtext.replace(/\s/g, ''))
             }
 
@@ -3354,57 +3346,107 @@ $(function () {
 
         loadDefaultImages()
 
-        $('.select-reverse').on('click', function (e) {
+        $('.pokemon-select-filtered').on('click', function (e) {
             e.preventDefault()
-            var selectlist = []
             var parent = $(this).parent().parent()
-            var pokeselectlist = parent.find('.pokemon-icon-sprite')
-            pokeselectlist.removeClass('active')
-            pokeselectlist = parent.find('.pokemon-icon-sprite:hidden')
-            pokeselectlist.addClass('active')
-            $('.hidepreset').removeClass('active')
-
-            $.each(pokeselectlist, function (i, item) {
-                var pokemonicon = $(this)
-                selectlist.push(pokemonicon.data('value'))
+            var inputElement = $(this).parent().parent().find('input[id$=pokemon]')
+            var selectedPokemons = inputElement.val().length > 0 ? inputElement.val().split(',') : []
+            var visibleNotActiveIconElements = parent.find('.pokemon-icon-sprite:visible:not(.active)')
+            visibleNotActiveIconElements.addClass('active')
+            $.each(visibleNotActiveIconElements, function (i, item) {
+                selectedPokemons.push($(this).data('value'))
             })
-            parent.find('input[id$=pokemon]').val(selectlist.join(',')).trigger('change')
+            parent.find('input[id$=pokemon]').val(selectedPokemons.join(',')).trigger('change')
         })
 
-        $('.select-all').on('click', function (e) {
+        $('.pokemon-deselect-filtered').on('click', function (e) {
             e.preventDefault()
-            var selectlist = []
             var parent = $(this).parent().parent()
-            var pokeselectlist = parent.find('.pokemon-icon-sprite')
-            pokeselectlist.removeClass('active')
-            pokeselectlist = parent.find('.pokemon-icon-sprite:visible')
-            pokeselectlist.addClass('active')
-            $('.hidepreset').removeClass('active')
-
-            $.each(pokeselectlist, function (i, item) {
-                var pokemonicon = $(this)
-                selectlist.push(pokemonicon.data('value'))
+            var inputElement = $(this).parent().parent().find('input[id$=pokemon]')
+            var selectedPokemons = inputElement.val().length > 0 ? inputElement.val().split(',') : []
+            var visibleActiveIconElements = parent.find('.pokemon-icon-sprite:visible.active')
+            visibleActiveIconElements.removeClass('active')
+            $.each(visibleActiveIconElements, function (i, item) {
+                var id = $(this).data('value').toString()
+                selectedPokemons = selectedPokemons.filter(function(item) {
+                    return item !== id
+                })
             })
-            parent.find('input[id$=pokemon]').val(selectlist.join(',')).trigger('change')
+            parent.find('input[id$=pokemon]').val(selectedPokemons.join(',')).trigger('change')
         })
-        $('.hide-all').on('click', function (e) {
+
+        $('.pokemon-select-unfiltered').on('click', function (e) {
             e.preventDefault()
             var parent = $(this).parent().parent()
-            $('.hidepreset').removeClass('active')
+            var selectedPokemons = []
+            var visibleActiveIconElements = parent.find('.pokemon-icon-sprite:visible.active')
+            var hiddenIconElements = parent.find('.pokemon-icon-sprite:hidden')
+            hiddenIconElements.addClass('active')
+            $.each(visibleActiveIconElements, function (i, item) {
+                selectedPokemons.push($(this).data('value'))
+            })
+            $.each(hiddenIconElements, function (i, item) {
+                selectedPokemons.push($(this).data('value'))
+            })
+            parent.find('input[id$=pokemon]').val(selectedPokemons.join(',')).trigger('change')
+        })
+
+        $('.pokemon-deselect-unfiltered').on('click', function (e) {
+            e.preventDefault()
+            var parent = $(this).parent().parent()
+            var selectedPokemons = []
+            var visibleActiveIconElements = parent.find('.pokemon-icon-sprite:visible.active')
+            var hiddenIconElements = parent.find('.pokemon-icon-sprite:hidden')
+            hiddenIconElements.removeClass('active')
+            $.each(visibleActiveIconElements, function (i, item) {
+                selectedPokemons.push($(this).data('value'))
+            })
+            parent.find('input[id$=pokemon]').val(selectedPokemons.join(',')).trigger('change')
+        })
+
+        $('.pokemon-select-all').on('click', function (e) {
+            e.preventDefault()
+            var parent = $(this).parent().parent()
+            parent.find('.list .pokemon-icon-sprite:visible').addClass('active')
+            parent.find('input[id$=pokemon]').val(pokemonIds.join(',')).trigger('change')
+        })
+
+        $('.pokemon-deselect-all').on('click', function (e) {
+            e.preventDefault()
+            var parent = $(this).parent().parent()
             parent.find('.list .pokemon-icon-sprite:visible').removeClass('active')
             parent.find('input[id$=pokemon]').val('').trigger('change')
         })
+
+        $('.quest-item-select-all').on('click', function (e) {
+            e.preventDefault()
+            var parent = $(this).parent().parent()
+            parent.find('.quest-item-list .quest-item-sprite').addClass('active')
+            parent.find('input[id$=items]').val(questItemIds.concat(new Array("6")).join(',')).trigger('change')
+        })
+
+        $('.quest-item-deselect-all').on('click', function (e) {
+            e.preventDefault()
+            var parent = $(this).parent().parent()
+            parent.find('.quest-item-list .quest-item-sprite').removeClass('active')
+            parent.find('input[id$=items]').val('').trigger('change')
+        })
+
         $selectExclude.on('change', function (e) {
             buffer = excludedPokemon
-            excludedPokemon = $selectExclude.val().split(',').map(Number).sort(function (a, b) {
-                return parseInt(a) - parseInt(b)
-            })
+            if ($selectExclude.val().length > 0) {
+                excludedPokemon = $selectExclude.val().split(',').map(Number).sort(function (a, b) {
+                    return a - b
+                })
+            } else {
+                excludedPokemon = []
+            }
             buffer = buffer.filter(function (e) {
                 return this.indexOf(e) < 0
             }, excludedPokemon)
             reincludedPokemon = reincludedPokemon.concat(buffer).map(String)
             clearStaleMarkers()
-            if (excludedPokemon.length === 1) {
+            if (excludedPokemon.length === 0) {
                 $('.pokemon-filter-active').text('*** No active Filter ***')
                 $('.pokemon-filter-active').css('color', 'black')
             } else {
@@ -3414,10 +3456,14 @@ $(function () {
             Store.set('remember_select_exclude', excludedPokemon)
         })
         $selectExcludeQuestPokemon.on('change', function (e) {
-            excludedQuestPokemon = $selectExcludeQuestPokemon.val().split(',').map(Number).sort(function (a, b) {
-                return parseInt(a) - parseInt(b)
-            })
-            if (excludedQuestPokemon.length === 1 && excludedQuestItems.length === 1) {
+            if ($selectExcludeQuestPokemon.val().length > 0) {
+                excludedQuestPokemon = $selectExcludeQuestPokemon.val().split(',').map(Number).sort(function (a, b) {
+                    return a - b
+                })
+            } else {
+                excludedQuestPokemon = []
+            }
+            if (excludedQuestPokemon.length === 0 && excludedQuestItems.length === 0) {
                 $('.quest-filter-active').text('*** No active Filter ***')
                 $('.quest-filter-active').css('color', 'black')
             } else {
@@ -3428,10 +3474,14 @@ $(function () {
             Store.set('remember_select_exclude_quest_pokemon', excludedQuestPokemon)
         })
         $selectExcludeQuestItems.on('change', function (e) {
-            excludedQuestItems = $selectExcludeQuestItems.val().split(',').map(Number).sort(function (a, b) {
-                return parseInt(a) - parseInt(b)
-            })
-            if (excludedQuestPokemon.length === 1 && excludedQuestItems.length === 1) {
+            if ($selectExcludeQuestItems.val().length > 0) {
+                excludedQuestItems = $selectExcludeQuestItems.val().split(',').map(Number).sort(function (a, b) {
+                    return a - b
+                })
+            } else {
+                excludedQuestItems = []
+            }
+            if (excludedQuestPokemon.length === 0 && excludedQuestItems.length === 0) {
                 $('.quest-filter-active').text('*** No active Filter ***')
                 $('.quest-filter-active').css('color', 'black')
             } else {
@@ -3450,15 +3500,19 @@ $(function () {
         })
         $selectPokemonNotify.on('change', function (e) {
             buffer = notifiedPokemon
-            notifiedPokemon = $selectPokemonNotify.val().split(',').map(Number).sort(function (a, b) {
-                return parseInt(a) - parseInt(b)
-            })
+            if ($selectPokemonNotify.val().length > 0) {
+                notifiedPokemon = $selectPokemonNotify.val().split(',').map(Number).sort(function (a, b) {
+                    return a - b
+                })
+            } else {
+                notifiedPokemon = []
+            }
             buffer = buffer.filter(function (e) {
                 return this.indexOf(e) < 0
             }, notifiedPokemon)
             reincludedPokemon = reincludedPokemon.concat(buffer).map(String)
             clearStaleMarkers()
-            if (notifiedPokemon.length === 1) {
+            if (notifiedPokemon.length === 0) {
                 $('.notify-filter-active').text('*** No active Filter ***')
                 $('.notify-filter-active').css('color', 'black')
             } else {

--- a/static/sass/layout/_nav.scss
+++ b/static/sass/layout/_nav.scss
@@ -193,8 +193,12 @@
     width: 100%;
 }
 
-.select-all {
-  margin-bottom: 5px;
+.filter-button-margin-small {
+    margin-bottom: 5px;
+}
+
+.filter-button-margin-big {
+    margin-bottom: 10px;
 }
 
 #pkid_list {

--- a/templates/map.html
+++ b/templates/map.html
@@ -285,7 +285,7 @@
                    <div class="quest-item-container">
                      <input id="exclude-quest-items" type="text" readonly="true" style="display:none;" >
                      <div class="quest-item-list"></div>
-                     <a href="#" class="quest-item-deselect-all">Show all</a>
+                     <a href="#" class="quest-item-deselect-all filter-button-margin-small">Show all</a>
                      <a href="#" class="quest-item-select-all">Hide all</a>
                     </div>
                   </label>

--- a/templates/map.html
+++ b/templates/map.html
@@ -269,8 +269,12 @@
                    <div class="pokemon-container">
                     <input id="exclude-quest-pokemon" type="text" readonly="true" style="display:none;" >
                     <div class="list"></div>
-                    <a href="#" class="select-all" style="display:none;">Hide filtered</a><a href="#" class="select-reverse" style="display:none;">Hide not filtered</a>
-                    <a href="#" class="hide-all">Show all</a>
+                    <a href="#" class="pokemon-deselect-filtered filter-button-margin-small" style="display:none;">Show filtered</a>
+                    <a href="#" class="pokemon-select-filtered filter-button-margin-big" style="display:none;">Hide filtered</a>
+                    <a href="#" class="pokemon-deselect-unfiltered filter-button-margin-small" style="display:none;">Show not filtered</a>
+                    <a href="#" class="pokemon-select-unfiltered" style="display:none;">Hide not filtered</a>
+                    <a href="#" class="pokemon-deselect-all filter-button-margin-small">Show all</a>
+                    <a href="#" class="pokemon-select-all">Hide all</a>
                    </div>
                   </label>
                  </div>
@@ -281,7 +285,8 @@
                    <div class="quest-item-container">
                      <input id="exclude-quest-items" type="text" readonly="true" style="display:none;" >
                      <div class="quest-item-list"></div>
-                     <a href="#" class="quest-item-show-all">Show all</a>
+                     <a href="#" class="quest-item-deselect-all">Show all</a>
+                     <a href="#" class="quest-item-select-all">Hide all</a>
                     </div>
                   </label>
                  </div>
@@ -333,8 +338,12 @@
                  <div class="pokemon-container">
                   <input id="exclude-pokemon" type="text" readonly="true" style="display:none;" >
                   <div class="list"></div>
-                  <a href="#" class="select-all" style="display:none;">Hide filtered</a><a href="#" class="select-reverse" style="display:none;">Hide not filtered</a>
-                  <a href="#" class="hide-all">Show all</a>
+                  <a href="#" class="pokemon-deselect-filtered filter-button-margin-small" style="display:none;">Show filtered</a>
+                  <a href="#" class="pokemon-select-filtered filter-button-margin-big" style="display:none;">Hide filtered</a>
+                  <a href="#" class="pokemon-deselect-unfiltered filter-button-margin-small" style="display:none;">Show not filtered</a>
+                  <a href="#" class="pokemon-select-unfiltered" style="display:none;">Hide not filtered</a>
+                  <a href="#" class="pokemon-deselect-all filter-button-margin-small">Show all</a>
+                  <a href="#" class="pokemon-select-all">Hide all</a>
                  </div>
                 </label>
                </div>
@@ -445,16 +454,18 @@
            </ul>
            <div id="tabs_notify-10">
             <div class="form-control">
-            <div class="notify-container">
-             <h3>Notify of Pokémon</h3>
              <label for="notify-pokemon">
               <div class="pokemon-container">
                <input id="notify-pokemon" type="text" readonly="true" style="display:none;" >
                <div class="list"></div>
-               <a href="#" class="select-all">Notify selection</a><a href="#" class="hide-all">Notify none</a>
+               <a href="#" class="pokemon-select-filtered filter-button-margin-small" style="display:none;">Notify of filtered</a>
+               <a href="#" class="pokemon-deselect-filtered filter-button-margin-big" style="display:none;">Don't notify of filtered</a>
+               <a href="#" class="pokemon-select-unfiltered filter-button-margin-small" style="display:none;">Notify of not filtered</a>
+               <a href="#" class="pokemon-deselect-unfiltered" style="display:none;">Don't notify of not filtered</a>
+               <a href="#" class="pokemon-select-all filter-button-margin-small">Notify of all</a>
+               <a href="#" class="pokemon-deselect-all">Notify of none</a>
               </div>
              </label>
-            </div>
             </div>
            </div>
            <div id="tabs_notify-11">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds some extra filtering options to the pokemon filter. Now all pokemon can be deselected/shown at once. This PR also fixes the bug where 0 was added to the list with excluded pokemon. This happened because split() called on an empty string returns a non empty array containing only the element 0.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
People wanted this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local instance.

## Screenshots (if appropriate):
Show all button:
![image](https://user-images.githubusercontent.com/22012675/60582635-7d503680-9d89-11e9-8d9a-9b193adef432.png)

Show filtered buttons when searching:
![image](https://user-images.githubusercontent.com/22012675/60582696-9a850500-9d89-11e9-97dd-718a1958c705.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
