### PR TITLE
Added total of currently visible mons to stats

### DIFF
--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -41,6 +41,8 @@ function countMarkers(map) { // eslint-disable-line no-unused-vars
             }
         })
 
+        document.getElementById('stats-pkmn-label').innerHTML = 'Pokémon (' + pkmnTotal + ')'
+
         var pokeCounts = []
 
         for (i = 0; i < pkmnCount.length; i++) {


### PR DESCRIPTION
## Description
See live updated total of currently visible mons in view area.

## Motivation and Context
Useful to quickly determine map device health and extra event spawns.

## How Has This Been Tested?
Used it for months, no problems.

## Screenshots (if appropriate):
![StatsTotalMon](https://user-images.githubusercontent.com/2234131/61780317-9be2a400-ae02-11e9-85c2-d73380131a0c.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
