### PR TITLE
Add discord blacklist, and support for required roles on multiple servers

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -98,14 +98,16 @@
 # then add that bot to your guild (server) using this link: https://discordapp.com/api/oauth2/authorize?client_id=YOUR_CLIENT_ID&scope=bot
 # Note that the required-roles feature requires a configuration with a single required guild.
 
-#user-auth-service:             # Force end users to auth to an external service. Supported: Discord
-#uas-client-id:                 # OAuth2 Client ID.
-#uas-client-secret:             # OAuth2 Client Secret. Client should have auth callback url of <yourserverurl>/auth_callback
-#uas-host-override              # override auth redirect host.
-#uas-discord-required-guilds    # (Optional) If guild ID(s) are specified, user must be in at least one discord guild (server) to access map. Comma separated if multiple.
-#uas-discord-guild-invite       # Invite link to redirect user to if user is not in above guild(s)
-#uas-discord-required-roles     # (Optional) If specified, user must be in one of these discord roles. Comma separated list of role ids. Requires bot configured below. Only supports single required guild.
-#uas-discord-bot-token          # Token for bot with access to your guild. Only required for required-roles feature
+#user-auth-service:               # Force end users to auth to an external service. Supported: Discord
+#uas-client-id:                   # OAuth2 Client ID.
+#uas-client-secret:               # OAuth2 Client Secret. Client should have auth callback url of <yourserverurl>/auth_callback
+#uas-host-override                # override auth redirect host.
+#uas-discord-required-guilds      # (Optional) If guild ID(s) are specified, user must be in at least one discord guild (server) to access map. Comma separated if multiple.
+#uas-discord-guild-invite         # Invite link to redirect user to if user is not in above guild(s)
+#uas-discord-blacklisted-guilds   # (Optional) If guild ID(s) are specified, user must not be in any of these guilds (servers) to access map. Comma separated if multiple.
+#uas-discord-blacklisted-redirect # (Optional) Link to redirect user to if user is in a blacklisted guild
+#uas-discord-required-roles       # (Optional) If specified, user must be in one of these discord roles. Comma separated list of role ids. Requires bot configured below. Only supports single required guild.
+#uas-discord-bot-token            # Token for bot with access to your guild. Only required for required-roles feature
 
 
 # Parks

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -238,12 +238,12 @@ def get_args():
                               'external authentication.'))
     parser.add_argument('-uasdgi', '--uas-discord-guild-invite', default=None,
                         help='Link for users not in required guild.')
-    parser.add_argument('-uadbg', '--uas-discord-blacklisted-guilds',
+    parser.add_argument('-uasdbg', '--uas-discord-blacklisted-guilds',
                         default=None,
                         help=('Blacklisted Discord Guild(s) for user ' +
                               'external authentication.'))
-    parser.add_argument('-uasdgi', '--uas-discord-guild-invite', default=None,
-                        help='Link for users not in required guild.')
+    parser.add_argument('-uasdbr', '--uas-discord-blacklisted-redirect', default=None,
+                        help='Link to redirect user to if user is in a blacklisted guild.')
     parser.add_argument('-uasdrr', '--uas-discord-required-roles',
                         default=None,
                         help=('Required Discord Guild Role(s) ' +

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -238,6 +238,12 @@ def get_args():
                               'external authentication.'))
     parser.add_argument('-uasdgi', '--uas-discord-guild-invite', default=None,
                         help='Link for users not in required guild.')
+    parser.add_argument('-uadbg', '--uas-discord-blacklisted-guilds',
+                        default=None,
+                        help=('Blacklisted Discord Guild(s) for user ' +
+                              'external authentication.'))
+    parser.add_argument('-uasdgi', '--uas-discord-guild-invite', default=None,
+                        help='Link for users not in required guild.')
     parser.add_argument('-uasdrr', '--uas-discord-required-roles',
                         default=None,
                         help=('Required Discord Guild Role(s) ' +


### PR DESCRIPTION
## Description
This adds two new settings:

uas-discord-blacklisted-guilds - takes a comma separated list of guilds who are blocked from access to the map
uas-discord-blacklisted-redirect - the URL to redirect blacklisted guilds to

It also adds support for uas-discord-required-roles to support required roles on multiple servers, it does this by allowing you to specify server id and role id in the format "[serverid:]\<roleid\>", this maintains compatibility with old role settings and uses the first required guild if a [serverid:] is not specified.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I host MAD/RM for a few communities in my area, being able to lock down the map to a role on multiple discords helps us keep access to the map to only the people we want to, as for blacklisted guilds, there's a guild in my area that wants to block kids from being in the community, so I block them from the map ¯\\\_(ツ)\_/¯

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I have tested this on my instance for around 24 hours with no reports of issues, hopefully it doesn't break anything.
<!--- Include details of your testing environment, and the tests you ran to -->
I run Rocketmap inside a Docker container, tested that I can still login, that blacklisted discords work, and that users are still able to get access.
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ ] My code follows the code style of this project. 
I usually use black, flake8 seems to produce lots of problems outside of my code - let me know if my code has issues and I'll happily sort it :)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
