### PR TITLE
check guilds/roles every 3600 seconds

### DIFF
--- a/pogom/client_auth.py
+++ b/pogom/client_auth.py
@@ -104,9 +104,17 @@ def _valid_auth(auth_code, host):
 
 def _is_in_guild(auth_code, guilds):
     user_guilds = auth_cache[auth_code].get('guilds')
+
+    if 'guilds_expires' not in auth_cache[auth_code] or auth_cache[auth_code]['guilds_expires'] < datetime.datetime.now():
+        user_guilds = []
+
     if not user_guilds:
         user_guilds = _get_user_guilds(auth_code)
         auth_cache[auth_code]['guilds'] = user_guilds
+        auth_cache[auth_code]['guilds_expires'] = (
+            datetime.datetime.now() +
+            datetime.timedelta(0, 3600))
+
     for g in user_guilds:
         if g['id'] in guilds:
             return True
@@ -115,9 +123,16 @@ def _is_in_guild(auth_code, guilds):
 
 def _has_role(auth_code, roles):
     user_roles = auth_cache[auth_code].get('roles')
+
+    if 'roles_expires' not in auth_cache[auth_code] or auth_cache[auth_code]['roles_expires'] < datetime.datetime.now():
+        user_roles = []
+
     if not user_roles:
         user_roles = _get_user_guild_roles(auth_code, required_guilds)
         auth_cache[auth_code]['roles'] = user_roles
+        auth_cache[auth_code]['roles_expires'] = (
+            datetime.datetime.now() +
+            datetime.timedelta(0, 3600))
 
     for guild in user_roles:
         for r in user_roles[guild]:


### PR DESCRIPTION
## Description
checking guilds and roles every 3600 second, so unauthorized will be logged out.

## Motivation and Context
currently users wich lost their guilds/roles can use the service until the discord auth token expires.

## How Has This Been Tested?
tested on local server instance

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
